### PR TITLE
feat: Add config files and launch scripts to separate sim and physical platforms     

### DIFF
--- a/config/tln_standard_physical.yaml
+++ b/config/tln_standard_physical.yaml
@@ -1,0 +1,14 @@
+tln_standard:
+  ros__parameters:
+    # Run on physical hardware: disables noise injection, enables deadman switch
+    sim: false
+
+    # Speed limits (m/s) — conservative defaults for physical car
+    min_speed: 1.0
+    max_speed: 6.0
+
+    # Use every Nth LiDAR beam (2 = half resolution)
+    downscale_factor: 2
+
+    # Path to the TFLite model
+    model_path: '/home/jackson/sim_ws/src/tln_variants/train/Models/TLN_Forza.tflite'

--- a/config/tln_standard_sim.yaml
+++ b/config/tln_standard_sim.yaml
@@ -1,0 +1,14 @@
+tln_standard:
+  ros__parameters:
+    # Run in simulation mode: enables LiDAR noise injection for sim-to-real transfer
+    sim: true
+
+    # Speed limits (m/s)
+    min_speed: 1.0
+    max_speed: 8.0
+
+    # Use every Nth LiDAR beam (2 = half resolution)
+    downscale_factor: 2
+
+    # Path to the TFLite model
+    model_path: '/home/jackson/sim_ws/src/tln_variants/train/Models/TLN_Forza.tflite'

--- a/launch/tln_standard_physical.launch.py
+++ b/launch/tln_standard_physical.launch.py
@@ -1,0 +1,22 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    config = os.path.join(
+        get_package_share_directory('tln_variants'),
+        'config',
+        'tln_standard_physical.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='tln_variants',
+            executable='tln_standard',
+            name='tln_standard',
+            parameters=[config],
+            output='screen',
+        )
+    ])

--- a/launch/tln_standard_sim.launch.py
+++ b/launch/tln_standard_sim.launch.py
@@ -1,0 +1,22 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    config = os.path.join(
+        get_package_share_directory('tln_variants'),
+        'config',
+        'tln_standard_sim.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='tln_variants',
+            executable='tln_standard',
+            name='tln_standard',
+            parameters=[config],
+            output='screen',
+        )
+    ])

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
-
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/tln_variants/tln_standard.py
+++ b/tln_variants/tln_standard.py
@@ -17,25 +17,35 @@ TLN_M = False
 class TLNStandard(Node):
     def __init__(self):
         super().__init__('tln_standard')
-        
+
         self.get_logger().info('TLNNode has been started.')
-        
-        
+
+        # Declare ROS2 parameters (overridable via config file or command line)
+        self.declare_parameter('sim', True)
+        self.declare_parameter('min_speed', 1.0)
+        self.declare_parameter('max_speed', 8.0)
+        self.declare_parameter('downscale_factor', 2)
+        self.declare_parameter('model_path', '/home/jackson/sim_ws/src/tln_variants/train/Models/TLN_Forza.tflite')
+
+        # Load parameters
+        self.sim = self.get_parameter('sim').value
+        self.init_min_speed = self.get_parameter('min_speed').value
+        self.init_max_speed = self.get_parameter('max_speed').value
+        self.downscale_factor = self.get_parameter('downscale_factor').value
+        self.model_path = self.get_parameter('model_path').value
+
         #global boolean for Autonomous control
         self.go = False
-        self.sim = True
-        self.init_min_speed = 1#1
-        self.init_max_speed = 8#8
         self.min_speed = self.init_min_speed
-        self.max_speed = self.init_max_speed        
-        
+        self.max_speed = self.init_max_speed
+
         self.launch = False
         self.launching = False
-        
+
         self.speed_mappings = [self.linear_map, self.exp_map_abs]
         self.speed_map = self.speed_mappings[0]
-        
-        
+
+
         self.ackermann_publisher = self.create_publisher(AckermannDriveStamped, '/drive', 10)
         # self.stats_publisher = self.create_publisher('/stats', 10)
         self.scan_subscription = self.create_subscription(LaserScan, '/scan', self.scan_callback, 10)
@@ -45,36 +55,22 @@ class TLNStandard(Node):
         # 0.1       10hz
         # 0.05      20hz
         # 0.025     40hz
-        
-        
+
+
         #timer to control dnn inference rate, rather than being limited by scan callback.
         self.timer = self.create_timer(0.0001, self.inference_dnn)
-        
-        #downscale factor for scans
-        self.downscale_factor = 2
-        
+
         #used to store intermediate scan
         self.scan = None
 
-        # self.model_path = "/home/jackson/sim_ws/src/tln_variants/train/Models/TLN_noquantized.tflite"
-        # self.model_path = "/home/jackson/sim_ws/src/tln_variants/models/TLN_sim_data_aus_mos_spl.tflite" # good
-        # self.model_path = "/home/jackson/sim_ws/src/tln_variants/models/TLN_Forza.tflite"
-        # self.model_path = "/home/jackson/sim_ws/src/tln_variants/models/Forza_GLC_smile_ot_ez.tflite" # almost good
-        # self.model_path = "/home/jackson/sim_ws/src/tln_variants/models/TLNETH_with_edgecases.tflite"
-        # self.model_path= "/home/jackson/sim_ws/src/tln_variants/train/Models/very_close.tflite"
-        
-        #TFlite
-        # self.model_path= "/home/jackson/sim_ws/src/tln_variants/train/Models/lidar_imitation_model_noquantized_d.tflite"
-        self.model_path= "/home/jackson/sim_ws/src/tln_variants/train/Models/TLN_Forza.tflite" # Last used
-        # self.model_path = "/home/jackson/sim_ws/src/tln_variants/train/Models/TLN_Forza_Oval_noquantized.tflite"
         self.interpreter = tf.lite.Interpreter(model_path=self.model_path)
         self.interpreter.allocate_tensors()
         self.input_index = self.interpreter.get_input_details()[0]["index"]
         self.output_index = self.interpreter.get_output_details()[0]["index"]
-        
-        self.get_logger().warn('TLN Node Ready.')
-        
-        if not(self.sim):
+
+        self.get_logger().warn(f'TLN Node Ready. sim={self.sim}, model={self.model_path}')
+
+        if not self.sim:
             self.get_logger().warn('Press right bumper to activate.')
 
     # Utility functions
@@ -179,9 +175,10 @@ class TLNStandard(Node):
                 scans = np.append(scans, [20]) #Only for Original TLN (541 scans)
             
                         
-            #Needs to be if sim == true -> Add noise
-            noise = np.random.normal(0, 0.5, scans.shape)
-            scans = scans + noise
+            # Add noise only in simulation to improve sim-to-real transfer
+            if self.sim:
+                noise = np.random.normal(0, 0.5, scans.shape)
+                scans = scans + noise
             
             #Clip values beyond 10m
             scans[scans > 10] = 10


### PR DESCRIPTION
Closes #1                                                                                                                                                                                                        
                                                                                                                                                                                                                   
  ## Summary                                                                                                                                                                                                       
  - Refactors `tln_standard` to declare all tunable values as ROS2 parameters                                                                                                                                      
    (`sim`, `min_speed`, `max_speed`, `downscale_factor`, `model_path`) loaded                                                                                                                                     
    at node startup instead of hardcoded                                                                                                                                                                           
  - Adds `config/tln_standard_sim.yaml` and `config/tln_standard_physical.yaml`                                                                                                                                    
    with platform-appropriate defaults                                                                                                                                                                             
  - Adds `launch/tln_standard_sim.launch.py` and `launch/tln_standard_physical.launch.py`                                                                                                                          
    that wire the correct config via `parameters=[config]`                                                                                                                                                         
  - Updates `setup.py` to install `config/*.yaml` and `launch/*.py` into the package share                                                                                                                         
  - Fixes noise injection to only run when `sim=True`                                                                                                                                                              
                                                                                                                                                                                                                   
  ## Usage                                                                                                                                                                                                         
  # Simulation                                                                                                                                                                                                     
  ros2 launch tln_variants tln_standard_sim.launch.py                                                                                                                                                              
                                                                                                                                                                                                                   
  # Physical car                                                                                                                                                                                                   
  ros2 launch tln_variants tln_standard_physical.launch.py                                                                                                                                                         
                                                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                                     
  - [ ] `colcon build --packages-select tln_variants` succeeds                                                                                                                                                     
  - [ ] Sim launch starts node with `sim=True` logged                                                                                                                                                              
  - [ ] Physical launch starts node with `sim=False` and deadman message shown                                                                                                                                     
  - [ ] `ros2 param get /tln_standard sim` returns correct value for each launch  